### PR TITLE
Add hotspot game link to home navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
                 <a href="#markets">夜市小吃</a>
                 <a href="food.html">西安美食大全</a>
                 <a href="news.html">美食快讯</a>
+                <a href="https://hotspotgame.online/" target="_blank" rel="noopener">热点游戏</a>
                 <a href="#contact">联系我们</a>
             </nav>
         </div>


### PR DESCRIPTION
## Summary
- add a Hotspot Game menu item to the home page navigation for quick access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c2a2bee88321a28cafe39a637edb